### PR TITLE
Adding PIC to STATIC libraries compilation

### DIFF
--- a/channel/CMakeLists.txt
+++ b/channel/CMakeLists.txt
@@ -13,3 +13,6 @@ target_include_directories(retif_channel
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+set_property(TARGET retif_channel
+    PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,3 +7,6 @@ target_include_directories(retif_common
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+set_property(TARGET retif_common
+    PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Now it builds properly on Fedora as well.

Closes #8.